### PR TITLE
Changes to CLI and ability to generate boot configurations at runtime

### DIFF
--- a/cmd/initialisation.go
+++ b/cmd/initialisation.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/thebsdbox/plunder/pkg/bootstraps"
 	"github.com/thebsdbox/plunder/pkg/utils"
 
 	log "github.com/Sirupsen/logrus"
@@ -12,14 +13,28 @@ import (
 )
 
 func init() {
-	plunderCmd.AddCommand(PlunderConfig)
-	plunderCmd.AddCommand(PlunderGet)
+	plunderCmd.AddCommand(plunderConfig)
+	plunderConfig.AddCommand(plunderServerConfig)
+	plunderConfig.AddCommand(plunderDeploymentConfig)
+
+	plunderCmd.AddCommand(plunderGet)
 
 }
 
 // PlunderConfig - This is for intialising a blank or partial configuration
-var PlunderConfig = &cobra.Command{
+var plunderConfig = &cobra.Command{
 	Use:   "config",
+	Short: "Initialise a plunder configuration",
+	Run: func(cmd *cobra.Command, args []string) {
+		log.SetLevel(log.Level(logLevel))
+		cmd.Help()
+		return
+	},
+}
+
+// PlunderServerConfig - This is for intialising a blank or partial configuration
+var plunderServerConfig = &cobra.Command{
+	Use:   "server",
 	Short: "Initialise a plunder configuration",
 	Run: func(cmd *cobra.Command, args []string) {
 		log.SetLevel(log.Level(logLevel))
@@ -34,8 +49,26 @@ var PlunderConfig = &cobra.Command{
 	},
 }
 
-// PlunderGet - The Get command will pull any required components (iPXE boot files)
-var PlunderGet = &cobra.Command{
+// PlunderDeploymentConfig - This is for intialising a blank or partial configuration
+var plunderDeploymentConfig = &cobra.Command{
+	Use:   "deployment",
+	Short: "Initialise a server configuration",
+	Run: func(cmd *cobra.Command, args []string) {
+		log.SetLevel(log.Level(logLevel))
+		var configuration []bootstraps.ConfigFile
+		configuration = append(configuration, bootstraps.ConfigFile{})
+		// Indent (or pretty-print) the configuration output
+		b, err := json.MarshalIndent(configuration, "", "\t")
+		if err != nil {
+			log.Fatalf("%v", err)
+		}
+		fmt.Printf("\n%s\n", b)
+		return
+	},
+}
+
+// plunderGet - The Get command will pull any required components (iPXE boot files)
+var plunderGet = &cobra.Command{
 	Use:   "get",
 	Short: "Get any components needed for bootstrapping (internet access required)",
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -5,6 +5,8 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/thebsdbox/plunder/pkg/bootstraps"
+
 	"github.com/thebsdbox/plunder/pkg/utils"
 
 	"github.com/thebsdbox/plunder/pkg/server"
@@ -17,7 +19,7 @@ import (
 var controller server.BootController
 var dhcpSettings server.DHCPSettings
 
-var gateway, dns, startAddress, configPath *string
+var gateway, dns, startAddress, configPath, deploymentPath *string
 
 var leasecount *int
 
@@ -55,7 +57,7 @@ func init() {
 
 	// Config File
 	configPath = PlunderServer.Flags().String("config", "", "Path to a plunder server configuration")
-
+	deploymentPath = PlunderServer.Flags().String("deployment", "", "Path to a plunder deployment configuration")
 	plunderCmd.AddCommand(PlunderServer)
 }
 
@@ -66,9 +68,18 @@ var PlunderServer = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		log.SetLevel(log.Level(logLevel))
 
+		// If deploymentPath is not blank then the flag has been used
+		if *deploymentPath != "" {
+			log.Infof("Reading deployment configuration from [%s]", *deploymentPath)
+			err := bootstraps.GenerateConfigFiles(*deploymentPath)
+			if err != nil {
+				log.Fatalf("%v", err)
+			}
+		}
+
 		// If configPath is not blank then the flag has been used
 		if *configPath != "" {
-			log.Infof("Reading configuration from [%s]", *configPath)
+			log.Infof("Reading server configuration from [%s]", *configPath)
 
 			// Check the actual path from the string
 			if _, err := os.Stat(*configPath); !os.IsNotExist(err) {

--- a/pkg/bootstraps/generator.go
+++ b/pkg/bootstraps/generator.go
@@ -1,0 +1,99 @@
+package bootstraps
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+// ServerConfig - Defines how a server will be configured by plunder
+type ServerConfig struct {
+	Gateway    string `json:"gateway"`
+	IPAddress  string `json:"address"`
+	Subnet     string `json:"subnet"`
+	NameServer string `json:"nameserver"`
+
+	NTPServer string `json:"ntpserver"`
+
+	Username string `json:"username"`
+	Password string `json:"password"`
+
+	RepositoryAddress string `json:"repoaddress"`
+	// MirrorDirectory is an Ubuntu specific config
+	MirrorDirectory string `json:"mirrordir"`
+
+	// SSHKeyPath will typically be loaded from a file ~/.ssh/id_rsa.pub
+	SSHKeyPath string `json:"sshkeypath"`
+}
+
+// ConfigFile - is used to parse the files containing all server configurations
+type ConfigFile struct {
+	MAC        string       `json:"mac"`
+	Deployment string       `json:"deployment"` // Either preseed or kickstart
+	Config     ServerConfig `json:"config"`
+}
+
+// ReadKeyFromFile - will attempt to read an sshkey from a file and populate the struct
+func (config *ServerConfig) ReadKeyFromFile(sshKeyPath string) error {
+	var buffer []byte
+	if _, err := os.Stat(sshKeyPath); !os.IsNotExist(err) {
+		buffer, err = ioutil.ReadFile(sshKeyPath)
+		if err != nil {
+			// Unable to read the file
+			return err
+		}
+	} else {
+		// File doesn't exist
+		return err
+	}
+	config.SSHKeyPath = string(buffer)
+	return nil
+}
+
+// GenerateConfigFiles will read a configuration file and build the iPXE files needed
+func GenerateConfigFiles(configFile string) error {
+	var configs []ConfigFile
+
+	// Check the actual path from the string
+	if _, err := os.Stat(configFile); !os.IsNotExist(err) {
+		configFile, err := ioutil.ReadFile(configFile)
+		if err != nil {
+			return err
+		}
+		json.Unmarshal(configFile, &configs)
+	} else {
+		return fmt.Errorf("Unable to open [%s]", configFile)
+	}
+	for i := range configs {
+		var newConfig string
+		switch configs[i].Deployment {
+		case "preseed":
+			// Build a preseed configuration and write it to disk
+			newConfig = configs[i].Config.BuildPreeSeedConfig()
+
+		case "kickstart":
+			// Build a kickstart configuration and write it to disk
+			newConfig = configs[i].Config.BuildKickStartConfig()
+
+		default:
+			return fmt.Errorf("Unknown deployment method [%s]", configs[i].Deployment)
+		}
+
+		filename := fmt.Sprintf("%s.cfg", configs[i].MAC)
+		f, err := os.Create(filename)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		byteCount, err := f.WriteString(newConfig)
+		if err != nil {
+			return err
+		}
+		log.Infof("Written %d bytes to file [%s]", byteCount, filename)
+		f.Sync()
+	}
+	return nil
+}

--- a/pkg/bootstraps/kickstart.go
+++ b/pkg/bootstraps/kickstart.go
@@ -2,14 +2,6 @@ package bootstraps
 
 import "fmt"
 
-// KickstartConfig contains all of the configuration detail specific to an Ubuntu/Debian instance
-type KickstartConfig struct {
-	Gateway    string
-	IPAddress  string
-	Subnet     string
-	NameServer string
-}
-
 // This initial template will be modifyable based upon the build requirements
 const kickstart = `
 install
@@ -173,7 +165,7 @@ yum clean all
 %end
 `
 
-// BuildConfig - Creates a new presseed configuration using the passed data
-func (u *KickstartConfig) BuildConfig() string {
+// BuildKickStartConfig - Creates a new presseed configuration using the passed data
+func (config *ServerConfig) BuildKickStartConfig() string {
 	return fmt.Sprintf("%s%s%s%s%s%s", preseed, preseedDisk, preseedNet, preseedPkg, preseedUsers, preseedCmd)
 }

--- a/pkg/bootstraps/preseed.go
+++ b/pkg/bootstraps/preseed.go
@@ -4,14 +4,6 @@ import (
 	"fmt"
 )
 
-// PreseedConfig contains all of the configuration detail specific to an Ubuntu/Debian instance
-type PreseedConfig struct {
-	Gateway    string
-	IPAddress  string
-	Subnet     string
-	NameServer string
-}
-
 // Preseed const, this is the basis for the configuration that will be modified per use-case
 const preseed = `
 # Force debconf priority to critical.
@@ -31,6 +23,9 @@ d-i clock-setup/utc boolean true
 d-i time/zone string Europe/GMT
 d-i clock-setup/ntp boolean true
 d-i clock-setup/ntp-server string 1.pl.pool.ntp.org
+
+### Preseed Early
+d-i preseed/early_command string kill-all-dhcp; netcfg
 `
 
 const preseedNet = `
@@ -47,8 +42,6 @@ d-i netcfg/get_nameservers string 8.8.8.8
 d-i netcfg/get_netmask string 255.255.255.0
 d-i netcfg/use_dhcp string
 d-i netcfg/disable_dhcp boolean true
-# HACK: https://www.debian.org/releases/wheezy/i386/apbs04.html.en#preseed-network
-d-i preseed/run string net-static.sh
 
 d-i netcfg/get_hostname string ubuntu
 d-i netcfg/get_domain string internal
@@ -156,7 +149,7 @@ d-i preseed/late_command string \
 	in-target chmod -R go-rwx /home/ubuntu/.ssh/authorized_keys;
 `
 
-// BuildConfig - Creates a new presseed configuration using the passed data
-func (u *PreseedConfig) BuildConfig() string {
+//BuildPreeSeedConfig - Creates a new presseed configuration using the passed data
+func (config *ServerConfig) BuildPreeSeedConfig() string {
 	return fmt.Sprintf("%s%s%s%s%s%s", preseed, preseedDisk, preseedNet, preseedPkg, preseedUsers, preseedCmd)
 }

--- a/pkg/utils/ipxe.go
+++ b/pkg/utils/ipxe.go
@@ -29,11 +29,11 @@ echo | mac.....: ${net0/mac}
 echo | gateway.: ${net0/gateway} 
 echo +------------------------------------------------------------
 echo .
-kernel http://%s/%s %s 
+kernel http://%s/%s auto=true url=http://%s/${mac:hexhyp}.cfg priority=critical %s 
 initrd http://%s/%s
 boot`
 	// Replace the addresses inline
-	buildScript := fmt.Sprintf(script, webserverAddress, kernel, cmdline, webserverAddress, initrd)
+	buildScript := fmt.Sprintf(script, webserverAddress, kernel, webserverAddress, cmdline, webserverAddress, initrd)
 
 	f, err := os.Create("./plunder.ipxe")
 	if err != nil {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -22,7 +22,7 @@ func WaitForCtrlC() {
 	endWaiter.Wait()
 }
 
-//FileToHex, this is a helper function to allow embedding files into .go files
+//FileToHex - this is a helper function to allow embedding files into .go files
 func FileToHex(filePath string) (sl string, err error) {
 
 	bs, err := ioutil.ReadFile(filePath)


### PR DESCRIPTION
The `plunder config` command now has two subcommands for outputting either the server configuration or the deployment configuration. The `plunder server` command now has an additional `--deployment` flag allowing `plunder` to create various iPxe boot files.