### PR TITLE
In-memory handlers

### DIFF
--- a/pkg/server/serve_dhcp.go
+++ b/pkg/server/serve_dhcp.go
@@ -52,8 +52,15 @@ func (h *DHCPSettings) ServeDHCP(p dhcp.Packet, msgType dhcp.MessageType, option
 		// Reply should have the configuration details in for iPXE to boot from
 		if string(options[77]) != "" {
 			if string(options[77]) == "iPXE" {
-				log.Debugf("Mac address is configured for [%s]", bootstraps.FindDeployment(mac))
-				h.Options[67] = []byte("http://" + h.IP.String() + "/plunder.ipxe")
+				deploymentType := bootstraps.FindDeployment(mac)
+				log.Debugf("Mac address is configured for [%s]", deploymentType)
+				// If this mac address has no deployment attached then reboot IPXE
+				if deploymentType == "" {
+					h.Options[67] = []byte("http://" + h.IP.String() + "/reboot.ipxe")
+				} else {
+					// Assign the deployment boot script
+					h.Options[67] = []byte("http://" + h.IP.String() + "/" + deploymentType + ".ipxe")
+				}
 			}
 		}
 		ipLease := dhcp.IPAdd(h.Start, free)

--- a/pkg/server/serve_http.go
+++ b/pkg/server/serve_http.go
@@ -1,30 +1,73 @@
 package server
 
 import (
+	"io"
 	"net/http"
-	"os"
 	"path/filepath"
 
 	"github.com/thebsdbox/plunder/pkg/utils"
-
-	log "github.com/Sirupsen/logrus"
 )
 
-func (c *BootController) serveHTTP() error {
-	if _, err := os.Stat("./plunder.ipxe"); os.IsNotExist(err) {
-		log.Println("Auto generating ./plunder.ipxe")
-		err = utils.GenerateiPXEScript(*c.HTTPAddress, *c.Kernel, *c.Initrd, *c.Cmdline)
-		if err != nil {
-			return err
-		}
-	}
+// These strings container the generated iPXE details that are passed to the bootloader when the correct url is requested
+var preseed, kickstart, reboot string
 
+func (c *BootController) serveHTTP() error {
+	// if _, err := os.Stat("./plunder.ipxe"); os.IsNotExist(err) {
+	// 	log.Println("Auto generating ./plunder.ipxe")
+	// 	err = utils.IPXEPreeseed(*c.HTTPAddress, *c.Kernel, *c.Initrd, *c.Cmdline)
+	// 	if err != nil {
+	// 		return err
+	// 	}
+	// }
+
+	preseed = utils.IPXEPreeseed(*c.HTTPAddress, *c.Kernel, *c.Initrd, *c.Cmdline)
+	kickstart = utils.IPXEKickstart(*c.HTTPAddress, *c.Kernel, *c.Initrd, *c.Cmdline)
+	reboot = utils.IPXEReboot()
 	docroot, err := filepath.Abs("./")
 	if err != nil {
 		return err
 	}
 
-	httpHandler := http.FileServer(http.Dir(docroot))
+	//httpRoot := http.FileServer(http.Dir(docroot)).ServeHTTP()
+	http.Handle("/", http.FileServer(http.Dir(docroot)))
+	//http.HandleFunc("/", httpRoot)
 
-	return http.ListenAndServe(":80", httpHandler)
+	http.HandleFunc("/health", HealthCheckHandler)
+	http.HandleFunc("/preseed.ipxe", preseedHandler)
+	http.HandleFunc("/reboot.ipxe", rebootHandler)
+	http.HandleFunc("/kickstart.ipxe", kickstartHandler)
+
+	return http.ListenAndServe(":80", nil)
+}
+
+func preseedHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	w.Header().Set("Content-Type", "text/plain")
+	// Return the preseed content
+	io.WriteString(w, preseed)
+}
+
+func kickstartHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	w.Header().Set("Content-Type", "text/plain")
+	// Return the kickstart content
+	io.WriteString(w, kickstart)
+}
+
+func rebootHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	w.Header().Set("Content-Type", "text/plain")
+	// Return the reboot content
+	io.WriteString(w, reboot)
+}
+
+// HealthCheckHandler -
+func HealthCheckHandler(w http.ResponseWriter, r *http.Request) {
+	// A very simple health check.
+	w.WriteHeader(http.StatusOK)
+	w.Header().Set("Content-Type", "application/json")
+
+	// In the future we could report back on the status of our DB, or our cache
+	// (e.g. Redis) by performing a simple PING, and include them in the response.
+	io.WriteString(w, `{"alive": true}`)
 }


### PR DESCRIPTION
This change means that all `plunder` ipxe files are now handled by the go `http handler` meaning less files need writing to a filesystem and they can be dynamically updated in the future.

Handlers are auto generated for the following urls:
`/preseed.ipxe`
`/reboot.ipxe`
`/kickstart.ipxe`