### PR TITLE
Fixes to iPXE configuration

### DIFF
--- a/pkg/bootstraps/generator.go
+++ b/pkg/bootstraps/generator.go
@@ -34,6 +34,7 @@ type ServerConfig struct {
 	NameServer string `json:"nameserver"`
 	ServerName string `json:"hostname"`
 	NTPServer  string `json:"ntpserver"`
+	Adapter    string `json:"adapter"`
 
 	Username string `json:"username"`
 	Password string `json:"password"`
@@ -154,6 +155,10 @@ func (config *ServerConfig) PopulateConfiguration() {
 	// Inherit the global Name Server (DNS)
 	if config.NameServer == "" {
 		config.NameServer = DeploymentConfig.GlobalServerConfig.NameServer
+	}
+
+	if config.Adapter == "" {
+		config.Adapter = DeploymentConfig.GlobalServerConfig.Adapter
 	}
 
 	// REPOSITORY CONFIGURATION

--- a/pkg/server/serve_dhcp.go
+++ b/pkg/server/serve_dhcp.go
@@ -32,11 +32,6 @@ func (h *DHCPSettings) ServeDHCP(p dhcp.Packet, msgType dhcp.MessageType, option
 	log.Debugf("DCHP Message Type: [%v] from MAC Address [%s]", msgType, mac)
 	switch msgType {
 	case dhcp.Discover:
-		// if string(options[77]) != "" {
-		// 	if string(options[77]) == "iPXE" {
-		// 		h.Options[67] = []byte("http://" + h.IP.String() + "/plunder.ipxe")
-		// 	}
-		// }
 		free, nic := -1, mac
 		for i, v := range h.Leases { // Find previous lease
 			if v.nic == nic {
@@ -53,11 +48,11 @@ func (h *DHCPSettings) ServeDHCP(p dhcp.Packet, msgType dhcp.MessageType, option
 		if string(options[77]) != "" {
 			if string(options[77]) == "iPXE" {
 				deploymentType := bootstraps.FindDeployment(mac)
-				log.Debugf("Mac address is configured for [%s]", deploymentType)
 				// If this mac address has no deployment attached then reboot IPXE
 				if deploymentType == "" {
-					log.Warnf("Mac address[%s] is unknown, rebooting server", mac)
-					h.Options[67] = []byte("http://" + h.IP.String() + "/reboot.ipxe")
+					log.Warnf("Mac address[%s] is unknown, not returning an address", mac)
+					return nil
+					//h.Options[67] = []byte("http://" + h.IP.String() + "/reboot.ipxe")
 				} else {
 					// Assign the deployment boot script
 					log.Infof("Mac address [%s] is assigned a [%s] deployment type", mac, deploymentType)

--- a/pkg/utils/ipxe.go
+++ b/pkg/utils/ipxe.go
@@ -32,7 +32,7 @@ echo .`
 // IPXEReboot -
 func IPXEReboot() string {
 	script := `
-echo MAC ADDRESS is unknown to, plunder, server will reboot in 5 seconds
+echo MAC ADDRESS is set to reboot, plunder will reboot the server in 5 seconds
 sleep 5
 reboot
 `
@@ -43,7 +43,7 @@ reboot
 // IPXEPreeseed - This will build an iPXE boot script for Debian/Ubuntu
 func IPXEPreeseed(webserverAddress string, kernel string, initrd string, cmdline string) string {
 	script := `
-kernel http://%s/%s auto=true url=http://%s/${mac:hexhyp}.cfg priority=critical %s 
+kernel http://%s/%s auto=true url=http://%s/${mac:hexhyp}.cfg priority=critical %s netcfg/choose_interface=${netX/mac}
 initrd http://%s/%s
 boot
 `


### PR DESCRIPTION
A lot of these changes are around the iPXE configuration for Ubuntu Preseed:
- The intial iPXE configuration will pass the MAC address of the boot adapter instead of a device name, this means that the boot process should succeed with multiple adapters
- The deployment configuraton takes an `adapter` configuration in both global and deployment for a server to ensure that the correct adapter is selected for the next IP address configuration.
- The disk format has been updated to a more modern `GPT` format, taken from preseed examples that have been written in the last two decades.
- DHCP has been updated to simply not respond to an unknown MAC address, however `reboot` is still an option when a server doesn't reboot by default.