### PR TITLE
Parlay parser

### DIFF
--- a/cmd/automate.go
+++ b/cmd/automate.go
@@ -90,13 +90,13 @@ var plunderAutomateValidate = &cobra.Command{
 	Use:   "validate",
 	Short: "Validate a deployment map",
 	Run: func(cmd *cobra.Command, args []string) {
-		if *mapFile != "" {
-			log.Infof("Reading deployment configuration from [%s]", *mapFile)
+		if *mapFileValidate != "" {
+			log.Infof("Reading deployment configuration from [%s]", *mapFileValidate)
 			//var err error
 			var deployment parlay.TreasureMap
 			// // Check the actual path from the string
-			if _, err := os.Stat(*mapFile); !os.IsNotExist(err) {
-				b, err := ioutil.ReadFile(*mapFile)
+			if _, err := os.Stat(*mapFileValidate); !os.IsNotExist(err) {
+				b, err := ioutil.ReadFile(*mapFileValidate)
 				if err != nil {
 					log.Fatalf("%v", err)
 				}

--- a/cmd/automate.go
+++ b/cmd/automate.go
@@ -11,11 +11,15 @@ import (
 	"github.com/thebsdbox/plunder/pkg/ssh"
 )
 
-var deploymentSSH, mapFile *string
+var deploymentSSH, mapFile, mapFileValidate *string
 
 func init() {
+	// SSH Deployment flags
 	deploymentSSH = plunderAutomateSSH.Flags().String("deployment", "", "Path to a plunder deployment configuration")
-	mapFile = plunderAutomateValidate.Flags().String("map", "", "Path to a plunder map")
+	mapFile = plunderAutomateSSH.Flags().String("map", "", "Path to a plunder map")
+
+	// Validation flags
+	mapFileValidate = plunderAutomateValidate.Flags().String("map", "", "Path to a plunder map")
 
 	// Automate SSH Flags
 	plunderAutomate.AddCommand(plunderAutomateValidate)
@@ -48,9 +52,35 @@ var plunderAutomateSSH = &cobra.Command{
 			if err != nil {
 				log.Fatalf("%v", err)
 			}
+		} else {
+			log.Warnln("No Deployment information imported")
+		}
+		log.Infof("Found [%d] ssh configurations", len(ssh.Hosts))
+
+		if *mapFile != "" {
+			log.Infof("Reading deployment configuration from [%s]", *mapFile)
+			//var err error
+			var deployment parlay.TreasureMap
+			// // Check the actual path from the string
+			if _, err := os.Stat(*mapFile); !os.IsNotExist(err) {
+				b, err := ioutil.ReadFile(*mapFile)
+				if err != nil {
+					log.Fatalf("%v", err)
+				}
+				err = json.Unmarshal(b, &deployment)
+				if err != nil {
+					log.Fatalf("%v", err)
+				}
+				// Begin the parsing
+				err = deployment.DeploySSH()
+				if err != nil {
+					log.Fatalf("%v", err)
+				}
+			} else {
+				log.Fatalf("%v", err)
+			}
 		}
 
-		log.Infof("Found [%d] ssh configurations", len(ssh.Hosts))
 		return
 	},
 }

--- a/pkg/parlay/parlay.go
+++ b/pkg/parlay/parlay.go
@@ -62,3 +62,8 @@ type Action struct {
 
 // Keys are used to store information between sessions and deployments
 var Keys map[string]string
+
+func init() {
+	// Initialise the map
+	Keys = make(map[string]string)
+}

--- a/pkg/parlay/parlay.go
+++ b/pkg/parlay/parlay.go
@@ -24,7 +24,7 @@ type Deployment struct {
 
 	// Parallel allow multiple actions across multiple hosts in parallel
 	Parallel         bool `json:"parallel"`
-	ParallelSessions int  `json:"sessions"`
+	ParallelSessions int  `json:"parallelSessions"`
 
 	// An array/list of hosts that these actions should be performed upon
 	Hosts   []string `json:"hosts"`
@@ -57,3 +57,8 @@ type Action struct {
 	KeyFile string `json:"keyFile,omitempty"`
 	KeyName string `json:"keyName,omitempty"`
 }
+
+// KeyMap
+
+// Keys are used to store information between sessions and deployments
+var Keys map[string]string

--- a/pkg/parlay/parser.go
+++ b/pkg/parlay/parser.go
@@ -2,40 +2,128 @@ package parlay
 
 import (
 	"fmt"
+	"os"
+	"os/exec"
 
 	"github.com/thebsdbox/plunder/pkg/ssh"
 )
 
 // DeploySSH - will iterate through a deployment and perform the relevant actions
-func (deployment *Deployment) DeploySSH() error {
+func (m *TreasureMap) DeploySSH() error {
 
 	if len(ssh.Hosts) == 0 {
 		return fmt.Errorf("No hosts credentials have been loaded")
 	}
-
-	// Build new hosts list from imported SSH servers and compare that we have required credentials
-	hosts, err := ssh.FindHosts(deployment.Hosts)
-	if err != nil {
-		return err
+	if len(m.Deployments) == 0 {
+		return fmt.Errorf("No Deployments in parlay map")
 	}
+	for x := range m.Deployments {
+		// Build new hosts list from imported SSH servers and compare that we have required credentials
+		hosts, err := ssh.FindHosts(m.Deployments[x].Hosts)
+		if err != nil {
+			return err
+		}
 
-	if deployment.Parallel == true {
-		for i := range deployment.Actions {
-			switch deployment.Actions[i].ActionType {
-			case "upload":
-				ssh.ParalellUpload(hosts, deployment.Actions[i].Source, deployment.Actions[i].Destination, deployment.Actions[i].Timeout)
-			case "download":
+		if m.Deployments[x].Parallel == true {
+			// Begin parallel work
+			for y := range m.Deployments[x].Actions {
+				switch m.Deployments[x].Actions[y].ActionType {
+				case "upload":
+					ssh.ParalellUpload(hosts, m.Deployments[x].Actions[y].Source, m.Deployments[x].Actions[y].Destination, m.Deployments[x].Actions[y].Timeout)
+				case "download":
 
-			case "command":
+				case "command":
 
-			case "pkg":
+				case "pkg":
 
-			case "key":
+				case "key":
 
-			default:
-				return fmt.Errorf("Unknown Action [%s]", deployment.Actions[i].ActionType)
+				default:
+					return fmt.Errorf("Unknown Action [%s]", m.Deployments[x].Actions[y].ActionType)
+				}
+			}
+		} else {
+			// Begin host by host deployments as part of each deployment
+			for z := range m.Deployments[x].Hosts {
+
+				var hostConfig ssh.HostSSHConfig
+				// Find the hosts SSH configuration
+				for i := range hosts {
+					if hosts[i].Host == m.Deployments[x].Hosts[z] {
+						hostConfig = hosts[i]
+					}
+				}
+
+				for y := range m.Deployments[x].Actions {
+					switch m.Deployments[x].Actions[y].ActionType {
+					case "upload":
+						hostConfig.UploadFile(m.Deployments[x].Actions[y].Source, m.Deployments[x].Actions[y].Destination)
+					case "download":
+						hostConfig.DownloadFile(m.Deployments[x].Actions[y].Source, m.Deployments[x].Actions[y].Destination)
+					case "command":
+						// Build out a configuration based upon the action
+						err = m.Deployments[x].Actions[y].parseAndExecute(&hostConfig)
+						if err != nil {
+							return err
+						}
+					case "pkg":
+
+					case "key":
+
+					default:
+						return fmt.Errorf("Unknown Action [%s]", m.Deployments[x].Actions[y].ActionType)
+					}
+				}
 			}
 		}
+	}
+
+	return nil
+}
+
+func (a *Action) parseAndExecute(h *ssh.HostSSHConfig) error {
+	// This will parse the options passed in the action and execute the required string
+	var command, result string
+	var err error
+
+	if a.CommandSudo != "" {
+		// Add sudo to the command
+		command = fmt.Sprintf("sudo %s %s", a.CommandSudo, a.Command)
+	} else {
+		command = a.Command
+	}
+
+	if a.CommandLocal == true {
+		b, err := exec.Command(command).Output()
+		if err != nil {
+			return err
+		}
+		result = string(b)
+	} else {
+		result, err = h.ExecuteCmd(command)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Save the results into a key to be used at another point
+	if a.CommandSaveAsKey != "" {
+		Keys[a.CommandSaveAsKey] = result
+	}
+
+	// Save the results into a file to be used at another point
+	if a.CommandSaveFile != "" {
+		f, err := os.Create(a.CommandSaveFile)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+
+		_, err = f.WriteString(result)
+		if err != nil {
+			return err
+		}
+		f.Sync()
 	}
 
 	return nil

--- a/pkg/ssh/sshClient.go
+++ b/pkg/ssh/sshClient.go
@@ -25,8 +25,18 @@ func ParalellExecute(cmd string, hosts []HostSSHConfig, to int) []CommandResult 
 	var cmdResults []CommandResult
 	// Run parallel ssh session (max 10)
 	results := make(chan CommandResult, 10)
-	timeout := time.After(time.Duration(to) * time.Second)
+	var d time.Duration
 
+	// Calculate the timeout
+	if to == 0 {
+		// If no timeout then default to one year (TODO)
+		d = time.Duration(8760) * time.Hour
+	} else {
+		d = time.Duration(to) * time.Second
+	}
+
+	// Set the timeout
+	timeout := time.After(d)
 	// Execute command on hosts
 	for _, host := range hosts {
 		go func(host HostSSHConfig) {
@@ -167,7 +177,19 @@ func ParalellUpload(hosts []HostSSHConfig, source, destination string, to int) [
 	var cmdResults []CommandResult
 	// Run parallel ssh session (max 10)
 	results := make(chan CommandResult, 10)
-	timeout := time.After(time.Duration(to) * time.Second)
+
+	var d time.Duration
+
+	// Calculate the timeout
+	if to == 0 {
+		// If no timeout then default to one year (TODO)
+		d = time.Duration(8760) * time.Hour
+	} else {
+		d = time.Duration(to) * time.Second
+	}
+
+	// Set the timeout
+	timeout := time.After(d)
 
 	// Execute command on hosts
 	for _, host := range hosts {

--- a/pkg/ssh/sshClient.go
+++ b/pkg/ssh/sshClient.go
@@ -1,7 +1,6 @@
 package ssh
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -44,7 +43,9 @@ func ParalellExecute(cmd string, hosts []HostSSHConfig, to int) []CommandResult 
 			res.Host = host.Host
 
 			if text, err := host.ExecuteCmd(cmd); err != nil {
+				// Report any returned values
 				res.Error = err
+				res.Result = text
 			} else {
 				res.Result = text
 			}
@@ -124,11 +125,9 @@ func (c *HostSSHConfig) ExecuteCmd(cmd string) (string, error) {
 		}
 	}
 
-	var stdoutBuf bytes.Buffer
-	c.Session.Stdout = &stdoutBuf
-	c.Session.Run(cmd)
+	b, err := c.Session.CombinedOutput(cmd)
 
-	return stdoutBuf.String(), nil
+	return string(b), err
 }
 
 // DownloadFile -


### PR DESCRIPTION
The first beta of the parsing engine named `parlay` has been completed and tested, Functionality is as follows:

- **Upload** Can upload files over `sftp` to remote hosts
- **Download** Can download files from remote hosts to local
- **Command** Can execute commands on remote hosts

**Command** 
Additional functionality has been added to the command function such as:
- Execute through `sudo`
- Save results as an in-memory key
- Save results to a file on the local storage
- Execute commands locally
- Execute a "key" remotely

Documentation is still required.

Any feedback @titpetric ?